### PR TITLE
Handle GAME_END action in MessageRouter

### DIFF
--- a/src/main/java/com/mycompany/tictactoeserver/domain/services/communication/MessageRouter.java
+++ b/src/main/java/com/mycompany/tictactoeserver/domain/services/communication/MessageRouter.java
@@ -5,6 +5,7 @@ import com.mycompany.tictactoeserver.domain.entity.AuthRequestEntity;
 import com.mycompany.tictactoeserver.domain.server.GameServerManager;
 import com.mycompany.tictactoeserver.domain.server.PlayerConnectionHandler;
 import com.mycompany.tictactoeserver.domain.services.authentication.AuthenticationService;
+import com.mycompany.tictactoeserver.domain.services.game.GameEndInfo;
 import com.mycompany.tictactoeserver.domain.services.game.GameManager;
 import com.mycompany.tictactoeserver.domain.services.game.GameRequestInfo;
 import com.mycompany.tictactoeserver.domain.services.game.GameResponseInfo;
@@ -127,6 +128,11 @@ if (response != null) {
             MoveInfo moveInfo = gson.fromJson(msg.getData(), MoveInfo.class);
             response = GameManager.getInstance().forwardMove(moveInfo);
             sender.sendMessageToPlayer(gson.toJson(response));
+        }
+         
+        case GAME_END->{
+            GameEndInfo Info = gson.fromJson(msg.getData(), GameEndInfo.class);
+            GameManager.getInstance().handleGameEnd(Info,sender);
         }
 
         default -> {

--- a/src/main/java/com/mycompany/tictactoeserver/domain/services/game/GameManager.java
+++ b/src/main/java/com/mycompany/tictactoeserver/domain/services/game/GameManager.java
@@ -327,7 +327,6 @@ public class GameManager {
                 opponent.sendMessageToPlayer(gson.toJson(endMsg));
             }
 
-            // Cleanup Room
             synchronized (lock) {
                 activeRooms.remove(room);
             }


### PR DESCRIPTION
Added support for the GAME_END message type in MessageRouter, allowing it to process game end events by invoking GameManager.handleGameEnd. Also removed a commented cleanup line in GameManager for clarity.